### PR TITLE
Avoid empty namespaces

### DIFF
--- a/src/eyeliner.rs
+++ b/src/eyeliner.rs
@@ -406,7 +406,7 @@ impl InsertPreservedCss for Eyeliner {
             let style_node = NodeRef::new_element(
                 QualName {
                     prefix: None,
-                    ns: ns!(),
+                    ns: ns!(html),
                     local: local_name!("style"),
                 },
                 vec![],


### PR DESCRIPTION
Otherwise html5ever gets unhappy with messages such as:

```
Mar 25 22:39:45.899  WARN html5ever::serialize: node with weird namespace Atom('' type=static)
```